### PR TITLE
Bug/evaluate training.py

### DIFF
--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -402,26 +402,27 @@ def preprocess(path_to_model, encoder_model, fname):
     testDataloader = DataGenerator(df_test,
                                    encoder_model=encoder_model,
                                    shuffle=True,
-                                   is_test=True)
+                                   is_test=True,
+                                   )
 
     # create prediction array from given file
     path_predictions = os.path.join(path_to_model, fname)
 
     Y_pred = np.genfromtxt(path_predictions)
-    Y_test = to_categorical(df_test['race_label'], num_classes=None)
+    Y_test = testDataloader.df['race_label'].values
     diff = (Y_test.shape[0] - Y_pred.shape[0])
+
     # Y_test erstellen, indem die verwendeten Indizes der Bilder verwendet
     # werden. Dann werden die gedroppt, die überstehen
-    values = df_test['race_label'].values
-    test = values[testDataloader.data_index]
-    Y_test = to_categorical(test[:-diff], num_classes=None)
+    Y_true = Y_test[testDataloader.data_index]
+    # if diff is equal to zero we get an empty array. We dont want this.
+    if diff is not 0:
+        Y_true = Y_true[:-diff]
 
     # Convert predictions classes to one hot vectors
     Y_cls = np.argmax(np.array(Y_pred), axis=1)
 
     # Convert validation observations to one hot vectors
-    Y_true = np.argmax(np.array(Y_test), axis=1)
-
     path_to_images = df_test['path_to_image'].values
     path_to_images = path_to_images[testDataloader.data_index]
     return Y_pred, Y_test, Y_cls, Y_true, path_to_images

--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -409,6 +409,7 @@ def preprocess(path_to_model, encoder_model, fname):
     path_predictions = os.path.join(path_to_model, fname)
 
     Y_pred = np.genfromtxt(path_predictions)
+    # The Dataloader converts the labels automatically into ahot vecotor
     Y_test = testDataloader.df['race_label'].values
     diff = (Y_test.shape[0] - Y_pred.shape[0])
 


### PR DESCRIPTION
If this difference
https://github.com/beckstev/MachineLearningSeminar/blob/19679ec84fd7443e54320935bba6d7a51196b060/dog_classifier/evaluate/evaluate_training.py#L412
is equal to zero the array `Y_test` will be initialiize as an empty array:
https://github.com/beckstev/MachineLearningSeminar/blob/19679ec84fd7443e54320935bba6d7a51196b060/dog_classifier/evaluate/evaluate_training.py#L417

I added a if-condition to catch this bug. 
Furthermore, I used the dataframe saved inside the dataloader to get the race labels. The reason for this is that the datloader converts the initial race labels automatically into a hot vector: 

https://github.com/beckstev/MachineLearningSeminar/blob/19679ec84fd7443e54320935bba6d7a51196b060/dog_classifier/net/dataloader.py#L58

I hope you can verify my changes. 