### PR TITLE
Bug/use rgb

### DIFF
--- a/dog_classifier/io/grid_search.py
+++ b/dog_classifier/io/grid_search.py
@@ -6,9 +6,8 @@ def find_parameters(training_parameters, batch_size,  use_rgb, l2_reg):
 
     permutations = np.array(np.meshgrid(batch_size, use_rgb, l2_reg)).T.reshape(-1,3)
 
-    permutations = np.array(np.meshgrid(batch_size, use_rgb, l2_reg)).T.reshape(-1, 3)
     for i in range(len(permutations)):
-        try:
+        # try:
             use_rgb = permutations[i, 1]
             print('\n')
             print('use rgb: ', use_rgb)
@@ -25,7 +24,7 @@ def find_parameters(training_parameters, batch_size,  use_rgb, l2_reg):
             training_parameters['l2_regularisation'] = l2_reg
 
             trainNN(training_parameters, grid_search=True)
-            
-        except Exception as e:
-            print(f'Error: {e} for the following perumation {permutations[i]}!')
-            continue
+
+        # except Exception as e:
+        #     print(f'Error: {e} for the following permutation {permutations[i]}!')
+        #     continue

--- a/dog_classifier/net/dataloader.py
+++ b/dog_classifier/net/dataloader.py
@@ -37,6 +37,7 @@ class DataGenerator(Sequence):
                                the y is equal to X
         :param seed: Set a seed for numpy random functions
         '''
+        print('Dataloader: ', use_rgb)
         self.df = df
         self.batch_size = batch_size
         self.encoder_model = encoder_model
@@ -103,13 +104,13 @@ class DataGenerator(Sequence):
                        (batch_size, number_of_classes). To create the matrix
                        the fucntion keras.utils.to_categorical is used.
         '''
-        if self.use_rgb is True:
+        if self.use_rgb == 1.0:
             # The function cv2.imread has an argument to read an image in RGB
             # or grayscale mode. 1 = RGB, 0 = Grayscale. Compare
             # https://docs.opencv.org/3.0-beta/doc/py_tutorials/py_gui/py_image_display/py_image_display.html
             colormode = 1
             n_channels = 3
-        else:
+        if self.use_rgb == 0.0:
             colormode = 0
             n_channels = 1
 

--- a/dog_classifier/net/dataloader.py
+++ b/dog_classifier/net/dataloader.py
@@ -101,7 +101,7 @@ class DataGenerator(Sequence):
                        containing the rescaled images of the batch.
             :return y: The labels of the images as 2D matrix
                        (batch_size, number_of_classes). To create the matrix
-                       the fucntion keras.utils.to_categorical is used.
+                       the function keras.utils.to_categorical is used.
         '''
         if self.use_rgb == 1.0:
             # The function cv2.imread has an argument to read an image in RGB
@@ -130,13 +130,19 @@ class DataGenerator(Sequence):
 
             image = cv.imread(path_to_image, colormode) * 1/255
             # save_img = image[..., ::-1]
-            # plt.imshow(save_img)
+            # plt.imshow(save_img, cmap='Greys')
             # plt.axis('off')
             # plt.savefig('../saved_models/bilder/original_{}.png'.format(i), dpi=500, pad_inches=0, bbox_inches='tight')
             # plt.clf()
             rescaled_image = cv.resize(image, rescale_size)
 
             if self.is_test is False:
+                if self.use_rgb == 0.0:
+                    print(rescaled_image.shape)
+                    rescaled_image = rescaled_image.reshape(rescale_size[1],
+                                                            rescale_size[0],
+                                                            n_channels)
+                    print(rescaled_image.shape)
                 # get bboxes
                 bbox = np.array(self.df.loc[ID, "x1":"y4"].values, dtype='float32')
                 # generate translation and zoom limits from crop_range
@@ -172,8 +178,10 @@ class DataGenerator(Sequence):
                                                         ty=ty)
             X[i, ] = rescaled_image
 
+            # rescaled_image = rescaled_image.reshape(rescale_size[1],
+            #                                         rescale_size[0],)
             # save_img = rescaled_image[..., ::-1]
-            # plt.imshow(save_img)
+            # plt.imshow(save_img, cmap='Greys')
             # plt.axis('off')
             # plt.savefig('../saved_models/bilder/augmented_{}.png'.format(i), dpi=500, pad_inches=0, bbox_inches='tight')
             # plt.clf()

--- a/dog_classifier/net/dataloader.py
+++ b/dog_classifier/net/dataloader.py
@@ -135,14 +135,9 @@ class DataGenerator(Sequence):
             # plt.savefig('../saved_models/bilder/original_{}.png'.format(i), dpi=500, pad_inches=0, bbox_inches='tight')
             # plt.clf()
             rescaled_image = cv.resize(image, rescale_size)
-
-            # reshape if grayscale
-            if self.use_rgb == 0.0:
-                print(rescaled_image.shape)
-                rescaled_image = rescaled_image.reshape(rescale_size[1],
-                                                        rescale_size[0],
-                                                        n_channels)
-                print(rescaled_image.shape)
+            rescaled_image = rescaled_image.reshape(rescale_size[1],
+                                                    rescale_size[0],
+                                                    n_channels)
 
             if self.is_test is False:
                 # get bboxes

--- a/dog_classifier/net/dataloader.py
+++ b/dog_classifier/net/dataloader.py
@@ -37,7 +37,6 @@ class DataGenerator(Sequence):
                                the y is equal to X
         :param seed: Set a seed for numpy random functions
         '''
-        print('Dataloader: ', use_rgb)
         self.df = df
         self.batch_size = batch_size
         self.encoder_model = encoder_model
@@ -135,7 +134,6 @@ class DataGenerator(Sequence):
             # plt.axis('off')
             # plt.savefig('../saved_models/bilder/original_{}.png'.format(i), dpi=500, pad_inches=0, bbox_inches='tight')
             # plt.clf()
-
             rescaled_image = cv.resize(image, rescale_size)
 
             if self.is_test is False:

--- a/dog_classifier/net/dataloader.py
+++ b/dog_classifier/net/dataloader.py
@@ -136,13 +136,15 @@ class DataGenerator(Sequence):
             # plt.clf()
             rescaled_image = cv.resize(image, rescale_size)
 
+            # reshape if grayscale
+            if self.use_rgb == 0.0:
+                print(rescaled_image.shape)
+                rescaled_image = rescaled_image.reshape(rescale_size[1],
+                                                        rescale_size[0],
+                                                        n_channels)
+                print(rescaled_image.shape)
+
             if self.is_test is False:
-                if self.use_rgb == 0.0:
-                    print(rescaled_image.shape)
-                    rescaled_image = rescaled_image.reshape(rescale_size[1],
-                                                            rescale_size[0],
-                                                            n_channels)
-                    print(rescaled_image.shape)
                 # get bboxes
                 bbox = np.array(self.df.loc[ID, "x1":"y4"].values, dtype='float32')
                 # generate translation and zoom limits from crop_range

--- a/dog_classifier/net/network.py
+++ b/dog_classifier/net/network.py
@@ -84,9 +84,14 @@ def DogNNv2(n_classes,l2_reg):
     return model
 
 
-def DogNNv3(n_classes, l2_reg):
+def DogNNv3(n_classes, l2_reg, use_rgb):
     # K.set_image_dim_ordering('th')
-    shape_input = (None, None, 3)
+    print('use_rgb DogNNv3:', use_rgb)
+    if use_rgb == 1.0:
+        shape_input = (None, None, 3)
+    else:
+        shape_input = (None, None, 1)
+    print('shape input: ', shape_input)
     model = Sequential()
     model.add(Conv2D(filters=4, kernel_size=(3, 3),
                      dilation_rate=(2, 2),

--- a/dog_classifier/net/network.py
+++ b/dog_classifier/net/network.py
@@ -21,9 +21,14 @@ class PRELU(PReLU):
         super(PRELU, self).__init__(**kwargs)
 
 
-def DogNN(n_classes, l2_reg):
+def DogNN(n_classes, l2_reg, use_rgb):
     # K.set_image_dim_ordering('th')
-    shape_input = (None, None, 3)
+    print('use_rgb DogNNv3:', use_rgb)
+    if use_rgb == 1.0:
+        shape_input = (None, None, 3)
+    else:
+        shape_input = (None, None, 1)
+    print('shape input: ', shape_input)
 
     model = Sequential()
     # number of params = ( kernel_size * channels + 1) * filters, +1 is bias
@@ -41,9 +46,14 @@ def DogNN(n_classes, l2_reg):
     return model
 
 
-def DogNNv2(n_classes,l2_reg):
+def DogNNv2(n_classes, l2_reg, use_rgb):
     # K.set_image_dim_ordering('th')
-    shape_input = (None, None, 3)
+    print('use_rgb DogNNv3:', use_rgb)
+    if use_rgb == 1.0:
+        shape_input = (None, None, 3)
+    else:
+        shape_input = (None, None, 1)
+    print('shape input: ', shape_input)
     model = Sequential()
     model.add(Conv2D(filters=4, kernel_size=(3, 3),
                      dilation_rate=(2, 2),
@@ -122,9 +132,13 @@ def DogNNv3(n_classes, l2_reg, use_rgb):
     return model
 
 
-
-def MiniDogNN(n_classes, l2_reg):
-    shape_input = (None, None, 3)
+def MiniDogNN(n_classes, l2_reg, use_rgb):
+    print('use_rgb DogNNv3:', use_rgb)
+    if use_rgb == 1.0:
+        shape_input = (None, None, 3)
+    else:
+        shape_input = (None, None, 1)
+    print('shape input: ', shape_input)
     model = Sequential()
     model.add(Conv2D(filters=8, kernel_size=(3, 3),
                      kernel_initializer=he_normal(),
@@ -169,6 +183,7 @@ def MiniDogNN(n_classes, l2_reg):
 
     return model
 
+
 def PreDogNN():
     l2_value = 0.01
     drop_rate = 0.2
@@ -199,6 +214,7 @@ def PreDogNN():
     model.add(Dense(5, activation='softmax'))
 
     return model
+
 
 def PreBigDogNN(n_classes):
     l2_value = 0.01

--- a/dog_classifier/net/train.py
+++ b/dog_classifier/net/train.py
@@ -17,13 +17,13 @@ from dog_classifier.evaluate import evaluate_training
 
 def get_model(model_name, n_classes, l2_reg, use_rgb):
     if model_name == 'DogNN':
-        return DogNN(n_classes, l2_reg)
+        return DogNN(n_classes, l2_reg, use_rgb)
     elif model_name == 'DogNNv2':
-        return DogNNv2(n_classes, l2_reg)
+        return DogNNv2(n_classes, l2_reg, use_rgb)
     elif model_name == 'PreBigDogNN':
         return PreBigDogNN(n_classes)
     elif model_name == 'MiniDogNN':
-        return MiniDogNN(n_classes, l2_reg)
+        return MiniDogNN(n_classes, l2_reg, use_rgb)
     elif model_name == 'DogNNv3':
         return DogNNv3(n_classes, l2_reg, use_rgb)
     elif model_name == 'PreDogNN':

--- a/dog_classifier/net/train.py
+++ b/dog_classifier/net/train.py
@@ -51,6 +51,8 @@ def get_train_and_val_dataloader(training_parameters, is_autoencoder=False):
     bs_size = training_parameters['batch_size']
     n_classes = training_parameters['n_classes']
     img_resize = training_parameters['img_resize']
+    use_rgb = training_parameters['use_rgb']
+    print('training_parameters: ', use_rgb)
 
     df_train = pd.read_csv(path_to_labels + 'train_labels.csv')
     df_val = pd.read_csv(path_to_labels + 'val_labels.csv')
@@ -59,13 +61,15 @@ def get_train_and_val_dataloader(training_parameters, is_autoencoder=False):
                                         batch_size=bs_size,
                                         n_classes=n_classes,
                                         const_img_resize=img_resize,
-                                        is_autoencoder=is_autoencoder)
+                                        is_autoencoder=is_autoencoder,
+                                        use_rgb=use_rgb)
 
         valDataloader = DataGenerator(df_val, encoder_model,
                                       batch_size=bs_size,
                                       n_classes=n_classes,
                                       const_img_resize=img_resize,
-                                      is_autoencoder=is_autoencoder)
+                                      is_autoencoder=is_autoencoder,
+                                      use_rgb=use_rgb)
 
     return trainDataloader, valDataloader
 

--- a/dog_classifier/net/train.py
+++ b/dog_classifier/net/train.py
@@ -15,7 +15,7 @@ from dog_classifier.net.network import DogNN, DogNNv2, DogNNv3, MiniDogNN, PreDo
 from dog_classifier.evaluate import evaluate_training
 
 
-def get_model(model_name, n_classes, l2_reg):
+def get_model(model_name, n_classes, l2_reg, use_rgb):
     if model_name == 'DogNN':
         return DogNN(n_classes, l2_reg)
     elif model_name == 'DogNNv2':
@@ -25,7 +25,7 @@ def get_model(model_name, n_classes, l2_reg):
     elif model_name == 'MiniDogNN':
         return MiniDogNN(n_classes, l2_reg)
     elif model_name == 'DogNNv3':
-        return DogNNv3(n_classes, l2_reg)
+        return DogNNv3(n_classes, l2_reg, use_rgb)
     elif model_name == 'PreDogNN':
         return PreDogNN()
     else:
@@ -52,7 +52,6 @@ def get_train_and_val_dataloader(training_parameters, is_autoencoder=False):
     n_classes = training_parameters['n_classes']
     img_resize = training_parameters['img_resize']
     use_rgb = training_parameters['use_rgb']
-    print('training_parameters: ', use_rgb)
 
     df_train = pd.read_csv(path_to_labels + 'train_labels.csv')
     df_val = pd.read_csv(path_to_labels + 'val_labels.csv')
@@ -135,7 +134,7 @@ def trainNN(training_parameters, grid_search=False):
     early_stopping_patience = training_parameters['early_stopping_patience']
     early_stopping_delta = training_parameters['early_stopping_delta']
 
-    model = get_model(training_parameters['architecture'], n_classes, l2_reg)
+    model = get_model(training_parameters['architecture'], n_classes, l2_reg, training_parameters['use_rgb'])
     # Set the leranrning rate of adam optimizer
     adam = Adam(lr=training_parameters['learning_rate'])
 

--- a/scripts/input_plot.py
+++ b/scripts/input_plot.py
@@ -24,7 +24,8 @@ def generate_batch(batch_size):
     encoder_model = 'encoder_2019-06-20_14:43:56.npy'
     df_train = pd.read_csv(path_to_labels + 'train_labels.csv')
     trainDataloader = DataGenerator(df_train, encoder_model,
-                                    batch_size=batch_size)
+                                    batch_size=batch_size,
+                                    use_rgb=False)
     for i in range(batch_size):
         X, y = trainDataloader.__getitem__(i)
 

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -42,11 +42,6 @@ if __name__ == '__main__':
     if args.early_stopping_delta:
         early_stopping_delta = args.early_stopping_delta
 
-    if args.use_rgb:
-        norm_mean, norm_std = [0.485, 0.456, 0.406], [0.229, 0.224, 0.225]
-    else:
-        norm_mean, norm_std = [0.5], [0.2]
-
     n_classes = 120
     if args.n_classes:
         n_classes = args.n_classes
@@ -63,9 +58,6 @@ if __name__ == '__main__':
                            'encoder_model': args.encoder_model,
                            'early_stopping_patience': early_stopping_patience,
                            'early_stopping_delta': early_stopping_delta,
-                           'normalization': {
-                                            'mean': norm_mean,
-                                            'std': norm_std},
                            'img_resize': img_resize
                            }
 


### PR DESCRIPTION
Heureka, es ist gefixt!

Features:

- Grayscale images get reshaped before data augmentation

- some changes to `plot_input`, so that one can plot grayscale input pictures

- changed `network.py` and `train.py`, so that the `input_shape` changes if rgb or grayscale images

Basically, one need to reshape the rescaled images, because `cv.imread` produces shapes like `(240, 140` and not `(240, 140, 1)`, which is requested by both transformation script and saving array.

To test: `python hyper_tuning.py` with various input NN. I also added some `print` orders, so that you can see how the shape changes. Feel free to delete them, if you are convinced that it works.

**Attention:** I did not change the `input_shape` of `PreDogNN` and `PreBigDogNN`, because we do not use `hyper_tuning.py` on them and i expect the grayscale images to be significantly worse to classify. So you will get an error, if you use `hyper_tuning.py` with this NNs.

I attached the input plot of grayscale images below.

[subplot.pdf](https://github.com/beckstev/MachineLearningSeminar/files/3389767/subplot.pdf)