### PR TITLE
Feature/loss tracker for dropout

### DIFF
--- a/dog_classifier/evaluate/eval_hyper_tuning.py
+++ b/dog_classifier/evaluate/eval_hyper_tuning.py
@@ -74,14 +74,10 @@ def create_3d_subplot(df, score, figure, position, polar, azimut):
 
     ax.scatter(xs=bs[mask_max], ys=np.log(l2[mask_max]), zs=use_rgb[mask_max],
                c='r', marker='*', label=f'Acc: {score[mask_max][0]:.2}')
-
-    # yticks = ax.get_yticks()
-    # ylabels = [f'{exp_str(tick):.2e}' for tick in yticks]
-    # ax.set_yticklabels(ylabels)
-
-    # zticks = ax.get_zticks()
-    # zlabels = [f'{exp_str(tick):.2e}' for tick in zticks]
-    # ax.set_zticklabels(zlabels)
+    # 0 = False, 1 = True
+    z_ticks = np.array([0, 1])
+    ax.set_zticks(z_ticks)
+    ax.set_zticklabels(['False', 'True'])
 
     ax.view_init(azimut, polar)
     return ax, scatter_plot

--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -10,6 +10,7 @@ from sklearn.metrics import classification_report
 from keras.models import load_model
 from dog_classifier.net.dataloader import DataGenerator
 from keras.utils import to_categorical
+import keras.backend as K
 from pathlib import Path
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
@@ -42,11 +43,14 @@ class HistoryEpoch(Callback):
     def on_train_begin(self, logs={}):
         self.loss = []
         self.acc = []
+        self.lr = []
 
     def on_epoch_end(self, epoch, logs={}):
         l, a = self.model.evaluate_generator(self.datagenerator, verbose=0)
+        lr = K.eval(self.model.optimizer.lr)
         self.loss.append(l)
         self.acc.append(a)
+        self.lr = [lr]
 
 
 def plot_history(network_history, path):

--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -50,7 +50,7 @@ class HistoryEpoch(Callback):
         lr = K.eval(self.model.optimizer.lr)
         self.loss.append(l)
         self.acc.append(a)
-        self.lr = [lr]
+        self.lr.append(lr)
 
 
 def plot_history(network_history, path):

--- a/dog_classifier/net/network.py
+++ b/dog_classifier/net/network.py
@@ -217,8 +217,8 @@ def PreDogNN():
 
 
 def PreBigDogNN(n_classes):
-    l2_value = 0.01
-    drop_rate = 0.2
+    l2_value = 0.007
+    drop_rate = 0.15
 
     conv_base = InceptionResNetV2(weights='imagenet',
                                   include_top=False,
@@ -235,14 +235,14 @@ def PreBigDogNN(n_classes):
                     kernel_regularizer=l2(l2_value)))
     model.add(PRELU(alpha_initializer=he_normal(),
                     weights=None))
-    #model.add(Dropout(rate=drop_rate))
+    model.add(Dropout(rate=drop_rate))
     model.add(Dense(120, kernel_initializer=he_normal(),
                     bias_initializer=he_normal(),
                     kernel_regularizer=l2(l2_value)))
     model.add(PRELU(alpha_initializer=he_normal(),
                     weights=None))
 
-    #model.add(Dropout(rate=drop_rate))
+    model.add(Dropout(rate=drop_rate))
     model.add(Dense(n_classes, activation='softmax'))
 
     return model

--- a/dog_classifier/net/train.py
+++ b/dog_classifier/net/train.py
@@ -50,7 +50,6 @@ def save_training_parameters(training_parameters, model_save_path):
     with open(model_save_path + '/training_parameters.json', 'w') as json_file:
         json.dump(training_parameters, json_file)
 
-
 def get_train_and_val_dataloader(training_parameters, is_autoencoder=False):
     path_to_labels = os.path.join(Path(os.path.abspath(__file__)).parents[2],
                                   "labels/")
@@ -60,7 +59,6 @@ def get_train_and_val_dataloader(training_parameters, is_autoencoder=False):
     n_classes = training_parameters['n_classes']
     img_resize = training_parameters['img_resize']
     use_rgb = training_parameters['use_rgb']
-
     df_train = pd.read_csv(path_to_labels + 'train_labels.csv')
     df_val = pd.read_csv(path_to_labels + 'val_labels.csv')
     with K.tf.device('/cpu:0'):
@@ -100,6 +98,19 @@ def save_final_loss_and_acc(history, model_save_path):
     with open(model_save_path + '/loss_acc.json', 'w') as json_file:
         json.dump(loss_dict, json_file)
 
+def save_epoch_history(trainHistoryEpoch, valHistoryEpoch, model_save_path):
+    loss_df = pd.DataFrame()
+
+    loss_df['val_loss'] = valHistoryEpoch.loss
+    loss_df['val_acc'] = valHistoryEpoch.acc
+    loss_df['loss'] = trainHistoryEpoch.acc
+    loss_df['acc'] = trainHistoryEpoch.acc
+    loss_df['lr'] = trainHistoryEpoch.lr
+
+    loss_df.to_csv(path_or_buf=model_save_path + '/model_history_epoch.csv',
+                   index=False)
+
+
 
 def trainNN(training_parameters, grid_search=False):
     ''' Traning a specific net architecture. Afterwards the paramters of the net
@@ -135,8 +146,6 @@ def trainNN(training_parameters, grid_search=False):
         os.makedirs(model_save_path)
 
     n_classes = training_parameters['n_classes']
-    encoder_model = training_parameters['encoder_model']
-    bs_size = training_parameters['batch_size']
     l2_reg = training_parameters['l2_regularisation']
     num_of_epochs = training_parameters['n_epochs']
     early_stopping_patience = training_parameters['early_stopping_patience']
@@ -205,6 +214,9 @@ def trainNN(training_parameters, grid_search=False):
         save_final_loss_and_acc(history, model_save_path)
 
     if loss_epoch_tracker:
+        save_epoch_history(train_loss_history_epoch,
+                           val_loss_history_epoch,
+                           model_save_path)
         evaluate_training.plot_history_epoch(train_loss_history_epoch,
                                              val_loss_history_epoch,
                                              path=model_save_path)

--- a/scripts/hyper_tuning.py
+++ b/scripts/hyper_tuning.py
@@ -13,7 +13,7 @@ if __name__ == '__main__':
     parser.add_argument('-d', '--early_stopping_delta', type=float)
     parser.add_argument('-n', '--n_classes', type=int, help='Number of classes to train. Default is 120')
     parser.add_argument('-ir', '--imgage_resize', type=tuple, help='Tuple (width, height) with determines the shape of the resized images')
-    
+
     args = parser.parse_args()
 
     n_epochs = int(5e2)
@@ -24,7 +24,7 @@ if __name__ == '__main__':
     if args.learning_rate:
         learning_rate = args.learning_rate
 
-    bs_size = [2, 5, 10, 15, 17, 25]
+    bs_size = [2, 5, 10, 15, 25]
     if args.batch_size:
         bs_size = args.batch_size
 

--- a/scripts/training.py
+++ b/scripts/training.py
@@ -12,7 +12,7 @@ if __name__ == '__main__':
     parser.add_argument('-l2', '--regularisation_rate', type=float)
     parser.add_argument('-p', '--early_stopping_patience', type=int)
     parser.add_argument('-d', '--early_stopping_delta', type=float)
-    parser.add_argument('-ir', '--imgage_resize', type=int, nargs=2, help='Tuple (width, height) with determines the shape of the resized images')
+    parser.add_argument('-ir', '--imgage_resize', type=int, nargs=2, help='Tuple (width, height) with determines the shape of the resized images. The networks "PreDogNN" and "PreBigDogNN" require a image size of 224x244')
     parser.add_argument('-n', '--n_classes', type=int, help='Number of classes to train. Default is 120')
     parser.add_argument('--use_rgb', action='store_true')
 
@@ -47,6 +47,10 @@ if __name__ == '__main__':
         n_classes = args.n_classes
 
     img_resize = tuple(args.imgage_resize) if args.imgage_resize else None
+
+    if args.architecture == ('PreDogNN') or ('PreBigDogNN'):
+        args.use_rgb = True
+        img_resize = (224, 224)
 
     training_parameters = {'n_classes': n_classes,
                            'batch_size': bs_size,


### PR DESCRIPTION
## Loss tracker for dropout

Added the functionality to save the loss and acc after each epoch whenever we are using `PreDogNN`  or `PreBigDogNN`. Therefore, I modified your `HistoryEpoch` class. 
In addition, I also merged the plot files for loss and acc into a single file containing two subplots. 

__How to test__

`python training.py <PreDogNN or PreBigDogNN> <#races associated encoder> -n <associated #races> -e 1`

-----

## Hypertuning

- Adapted the z-axis of the 3d scatter plot
- Removed bs 17 for hyper tunning, because it `tensorflow` always failed

