### PR TITLE
Bug/visualize pred

### DIFF
--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -427,7 +427,7 @@ def preprocess(path_to_model, encoder_model, fname):
 
 def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model, path):
     print('\nvisualize predictions \n')
-    plt.figure(figsize=(5.8, 3.58))
+    plt.figure(figsize=(6.224, 4))
 
     path = path + '/build/'
     if not os.path.exists(path):
@@ -440,7 +440,7 @@ def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model, path):
     encoder = LabelEncoder()
     encoder.classes_ = np.load(encoder_path)
 
-    for index in range(12, 18):
+    for index in range(24, 30):
         # Indices of the array represent the dog race
         race_index_true = Y_true[index]
         race_true = encoder.inverse_transform(np.array([race_index_true]))
@@ -451,7 +451,7 @@ def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model, path):
         races_high_pred = np.argsort(Y_pred[index])[-1:][::-1]
         races_pred = encoder.inverse_transform(races_high_pred)
 
-        plt.subplot(2, 3, index-11)
+        plt.subplot(2, 3, index-23)
 
         path_to_image = path_to_images[index]
         img = plt.imread(path_to_image)
@@ -466,7 +466,9 @@ def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model, path):
             prob = Y_pred[index][race_index_pred] * 100
             text = f"{races_pred[i].replace('_', ' ')}: {prob:.2f} \%"
             # plt.text(img_width * 51/50, (i + scale/2 - 1) * height_steps, text)
-            plt.text(img_width * 0.1, img_height + 50, text, fontsize=7)
+            # plt.text(img_width * 0.08, img_height * 1.09, text, fontsize=7)
+            plt.annotate(text, (0, 0), (0, -1), xycoords='axes fraction',
+                         textcoords='offset points', va='top', fontsize=7)
 
         plt.title(f'True race: {race_true[0]} ', fontsize=7)
         plt.axis('off')

--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing import LabelEncoder
 import sys
 from keras.utils.generic_utils import CustomObjectScope
 
-# mpl.use('pgf')
+mpl.use('pgf')
 mpl.rcParams.update(
     {'font.size': 10,
         'font.family': 'sans-serif',
@@ -425,14 +425,22 @@ def preprocess(path_to_model, encoder_model, fname):
     return Y_pred, Y_test, Y_cls, Y_true, path_to_images
 
 
-def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model):
+def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model, path):
+    print('\nvisualize predictions \n')
+    plt.figure(figsize=(5.8, 3.58))
+
+    path = path + '/build/'
+    if not os.path.exists(path):
+        os.makedirs(path)
+
     path_to_labels = os.path.join(Path(os.path.abspath(__file__)).parents[2],
                                   "labels/")
 
     encoder_path = os.path.join(path_to_labels, encoder_model)
     encoder = LabelEncoder()
     encoder.classes_ = np.load(encoder_path)
-    for index in range(len(Y_pred)):
+
+    for index in range(12, 18):
         # Indices of the array represent the dog race
         race_index_true = Y_true[index]
         race_true = encoder.inverse_transform(np.array([race_index_true]))
@@ -440,27 +448,32 @@ def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model):
 
         # Indicies of the three races with highest prohability
         # Notice: the last element of races_high_pred has the highest prob
-        races_high_pred = np.argsort(Y_pred[index])[-3:][::-1]
+        races_high_pred = np.argsort(Y_pred[index])[-1:][::-1]
         races_pred = encoder.inverse_transform(races_high_pred)
+
+        plt.subplot(2, 3, index-11)
 
         path_to_image = path_to_images[index]
         img = plt.imread(path_to_image)
         plt.imshow(img)
         img_width = img.shape[1]
         img_height = img.shape[0]
-        scale = 6
-        height_steps = img_height / 6
+        # scale = 6
+        # height_steps = img_height / 6
 
         for i in range(len(races_pred)):
             race_index_pred = races_high_pred[i]
             prob = Y_pred[index][race_index_pred] * 100
-            text = f"{races_pred[i].replace('_', ' ')}: \n {prob:.2f} \%"
-            plt.text(img_width * 51/50, (i + scale/2 - 1) * height_steps, text)
+            text = f"{races_pred[i].replace('_', ' ')}: {prob:.2f} \%"
+            # plt.text(img_width * 51/50, (i + scale/2 - 1) * height_steps, text)
+            plt.text(img_width * 0.1, img_height + 50, text, fontsize=7)
 
-        plt.title(f'True race: {race_true[0]} ')
+        plt.title(f'True race: {race_true[0]} ', fontsize=7)
         plt.axis('off')
         # plt.savefig('test.png', bbox_inches='tight', pad_inches=0.05)
-        plt.show()
+        # plt.show()
+    plt.savefig("{}/visualize_predictions.pdf".format(path), dpi=500,
+                pad_inches=0, bbox_inches='tight')
 
 
 def model_loader(path_to_model, main_model, checkpoint_model):
@@ -480,7 +493,8 @@ def model_loader(path_to_model, main_model, checkpoint_model):
             reply = str(input())
             if reply == 'y':
                 print('Using checkpoint model')
-                checkpoint_model_params = os.path.join(path_to_model, checkpoint_model)
+                checkpoint_model_params = os.path.join(path_to_model,
+                                                       checkpoint_model)
                 model = load_model(checkpoint_model_params)
             else:
                 print('Exiting program')

--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -344,7 +344,7 @@ def plot_predictions(n, model, X_test, height, width, path):
     plt.savefig("{}/plot_predictions.pdf".format(path))
 
 
-def predict(path_to_model, encoder_model, fname, img_resize):
+def predict(path_to_model, encoder_model, fname, img_resize, use_rgb):
     """function will predict with predict_generator from a given, saved model
     and save the result as txt
     :param path_to_model: Path to model
@@ -369,7 +369,8 @@ def predict(path_to_model, encoder_model, fname, img_resize):
                                    encoder_model=encoder_model,
                                    shuffle=True,
                                    is_test=True,
-                                   const_img_resize=img_resize)
+                                   const_img_resize=img_resize,
+                                   use_rgb=use_rgb)
 
     # Test predicten
     Y_pred = model.predict_generator(testDataloader, verbose=1)
@@ -434,7 +435,13 @@ def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model):
     for index in range(len(Y_pred)):
         # Indices of the array represent the dog race
         race_index_true = np.where(Y_true[index] == 1)
-        race_true = encoder.inverse_transform(race_index_true)
+
+        if np.shape(race_index_true) == (1, 0):
+            print('\n', race_index_true)
+            print('race_index_true is empty', '\n')
+            sys.exit(1)
+        else:
+            race_true = encoder.inverse_transform(race_index_true)
 
         # Indicies of the three races with highest prohability
         # Notice: the last element of races_high_pred  has the highest prob

--- a/dog_classifier/evaluate/evaluate_training.py
+++ b/dog_classifier/evaluate/evaluate_training.py
@@ -16,7 +16,7 @@ from sklearn.preprocessing import LabelEncoder
 import sys
 from keras.utils.generic_utils import CustomObjectScope
 
-mpl.use('pgf')
+# mpl.use('pgf')
 mpl.rcParams.update(
     {'font.size': 10,
         'font.family': 'sans-serif',
@@ -434,18 +434,13 @@ def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model):
     encoder.classes_ = np.load(encoder_path)
     for index in range(len(Y_pred)):
         # Indices of the array represent the dog race
-        race_index_true = np.where(Y_true[index] == 1)
-
-        if np.shape(race_index_true) == (1, 0):
-            print('\n', race_index_true)
-            print('race_index_true is empty', '\n')
-            sys.exit(1)
-        else:
-            race_true = encoder.inverse_transform(race_index_true)
+        race_index_true = Y_true[index]
+        race_true = encoder.inverse_transform(np.array([race_index_true]))
+        race_true = [cl.replace('_', ' ') for cl in race_true]
 
         # Indicies of the three races with highest prohability
-        # Notice: the last element of races_high_pred  has the highest prob
-        races_high_pred = np.argsort(Y_pred[index])[-3:]
+        # Notice: the last element of races_high_pred has the highest prob
+        races_high_pred = np.argsort(Y_pred[index])[-3:][::-1]
         races_pred = encoder.inverse_transform(races_high_pred)
 
         path_to_image = path_to_images[index]
@@ -459,7 +454,7 @@ def visualize_predictions(Y_pred, Y_true, path_to_images, encoder_model):
         for i in range(len(races_pred)):
             race_index_pred = races_high_pred[i]
             prob = Y_pred[index][race_index_pred] * 100
-            text = f"{races_pred[i]}: \n {prob:.2} %"
+            text = f"{races_pred[i].replace('_', ' ')}: \n {prob:.2f} \%"
             plt.text(img_width * 51/50, (i + scale/2 - 1) * height_steps, text)
 
         plt.title(f'True race: {race_true[0]} ')

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
                                                     fname_pred)
 
     # visualize_predictions
-    eval.visualize_predictions(Y_pred, Y_test, path_to_images, args.encoder_model)
+    eval.visualize_predictions(Y_pred, Y_true, path_to_images, args.encoder_model)
     # Multiclass-Analyse
     # eval.prob_multiclass(Y_pred, Y_test, Y_true, label=1, path=args.model_path)
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
                                                     fname_pred)
 
     # visualize_predictions
-    eval.visualize_predictions(Y_pred, Y_true, path_to_images, args.encoder_model)
+    eval.visualize_predictions(Y_pred, Y_true, path_to_images, args.encoder_model, path=args.model_path)
     # Multiclass-Analyse
     # eval.prob_multiclass(Y_pred, Y_test, Y_true, label=1, path=args.model_path)
 

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -11,6 +11,7 @@ if __name__ == '__main__':
     parser.add_argument('--fname_pred', type=str, help='file name of prediction file')
     parser.add_argument('-ir', '--imgage_resize', type=int, nargs=2, help='Tuple (width, height) with determines the shape of the resized images')
     parser.add_argument('--n', type=int, help='Number of classes. Default is 120')
+    parser.add_argument('--use_rgb', action='store_true')
 
     args = parser.parse_args()
     fname_pred = args.fname_pred if args.fname_pred else 'prediction.txt'
@@ -20,14 +21,14 @@ if __name__ == '__main__':
 
     if not os.path.isfile(args.model_path + '/prediction.txt'):
         eval.predict(args.model_path, args.encoder_model,
-                     fname_pred, img_resize)
+                     fname_pred, img_resize, args.use_rgb)
 
     Y_pred, Y_test, Y_cls, Y_true, path_to_images = eval.preprocess(args.model_path,
                                                     args.encoder_model,
                                                     fname_pred)
 
     # visualize_predictions
-    # eval.visualize_predictions(Y_pred, Y_test, path_to_images, args.encoder_model)
+    eval.visualize_predictions(Y_pred, Y_test, path_to_images, args.encoder_model)
     # Multiclass-Analyse
     # eval.prob_multiclass(Y_pred, Y_test, Y_true, label=1, path=args.model_path)
 


### PR DESCRIPTION
- Updated `visualize_predictions` and made a plot for the predictions. Added `model_path`, so that the plot will be stored in the `build` folder fot the patricular architecture, like the rest of the plots

- Also updated `predict`, because the Dataloader needs information about use_rgb (maybee we can undo that, because we predict only images with use_rgb=True).

- fixed bug for old version of
[visualize_predictions (2).pdf](https://github.com/beckstev/MachineLearningSeminar/files/3432800/visualize_predictions.2.pdf)
 `visualize_predictions`

To test: `python evaluate.py <model_path> <encoder_model> <number of classes> --use_rgb`